### PR TITLE
Bug Fix: handle likes

### DIFF
--- a/server/user.js
+++ b/server/user.js
@@ -60,15 +60,16 @@ router.put("/:user_id/likes/", (req, res) => {
       { _id: user_id },
       { $push: { likes: tweet_id } },
       // Returns the updated document
-      { new: true },
-      (err, user) => {
+      { new: true }
+    )
+      .then(user => {
         res.send({
           user,
           likes: user.likes,
           likesNum: user.likes.length
         });
-      }
-    ).catch(err => res.status(400).send(err));
+      })
+      .catch(err => res.status(400).send(err));
   } else if (action === "unlike") {
     User.findOneAndUpdate(
       { _id: user_id },


### PR DESCRIPTION
Bug: a liked tweet id is being pushed into user.likes multiple times in one request

findOneAndUpdate's 3rd parameter is a callback function.
sending the response via this callback function was causing the tweetId to be pushed into user.likes multiple times in the same request. 

sending the response via a .then() function solved the issue. 