### PR TITLE
Be/user feed

### DIFF
--- a/server/__tests__/server.test.js
+++ b/server/__tests__/server.test.js
@@ -271,3 +271,15 @@ describe("EDIT PROFILE", () => {
       .end(done);
   });
 });
+
+describe("FEED", () => {
+  it("Should return all posts from users being followed and posts by self", done => {
+    const user_id = "5aa054ac1a6e5a01b90f591c"; // Misoawesome
+
+    request(app)
+      .get(`users/${user_id}/feed`)
+      .expect(200)
+      .expect(res => {})
+      .end(done);
+  });
+});

--- a/server/__tests__/server.test.js
+++ b/server/__tests__/server.test.js
@@ -32,7 +32,7 @@ describe("TWEETS", () => {
       .get("/tweet/all")
       .expect(200)
       .expect(res => {
-        expect(res.body.length).toBe(4);
+        expect(res.body.length).toBe(5);
       })
       .end(done);
   });
@@ -74,7 +74,7 @@ describe("USERS", () => {
       .get("/user/all")
       .expect(200)
       .expect(res => {
-        expect(res.body.length).toBe(2);
+        expect(res.body.length).toBe(3);
       })
       .end(done);
   });
@@ -193,7 +193,7 @@ describe("FOLLOW", () => {
       .send(requestObj)
       .expect(200)
       .expect(res => {
-        expect(res.body.followingNum).toBe(0);
+        expect(res.body.followingNum).toBe(1);
         expect(res.body.following).not.toContain(user_id);
       })
       .end(done);
@@ -273,7 +273,7 @@ describe("EDIT PROFILE", () => {
 });
 
 describe("FEED", () => {
-  it.only("Should return all posts from users being followed and posts by self", done => {
+  it("Should return all posts from users being followed and posts by self", done => {
     const self_id = "5aa054ac1a6e5a01b90f591c"; // Misoawesome
 
     request(app)

--- a/server/__tests__/server.test.js
+++ b/server/__tests__/server.test.js
@@ -279,7 +279,9 @@ describe("FEED", () => {
     request(app)
       .get(`/user/${self_id}/feed`)
       .expect(200)
-      .expect(res => {})
+      .expect(res => {
+        expect(res.body.length).toBe(5);
+      })
       .end(done);
   });
 });

--- a/server/__tests__/server.test.js
+++ b/server/__tests__/server.test.js
@@ -273,11 +273,11 @@ describe("EDIT PROFILE", () => {
 });
 
 describe("FEED", () => {
-  it("Should return all posts from users being followed and posts by self", done => {
-    const user_id = "5aa054ac1a6e5a01b90f591c"; // Misoawesome
+  it.only("Should return all posts from users being followed and posts by self", done => {
+    const self_id = "5aa054ac1a6e5a01b90f591c"; // Misoawesome
 
     request(app)
-      .get(`users/${user_id}/feed`)
+      .get(`/user/${self_id}/feed`)
       .expect(200)
       .expect(res => {})
       .end(done);

--- a/server/__tests__/test-data.js
+++ b/server/__tests__/test-data.js
@@ -14,7 +14,7 @@ let testUsers = [
     firstName: "Miso",
     lastName: "Awesomely",
     likes: ["5aa05812fcbbc803417de0b8"],
-    following: ["5aa054ac1a6e5a01b90f591d"]
+    following: ["5aa054ac1a6e5a01b90f591d", "5aa054ac1a6e5a01b90f591e"]
   },
   {
     _id: "5aa054ac1a6e5a01b90f591d",
@@ -23,6 +23,12 @@ let testUsers = [
     lastName: "Looper",
     likes: ["5aa05812fcbbc803417de0b5"],
     followers: ["5aa054ac1a6e5a01b90f591c"]
+  },
+  {
+    _id: "5aa054ac1a6e5a01b90f591e",
+    username: "jackroads",
+    firstName: "jack",
+    lastName: "roads"
   }
 ];
 
@@ -56,6 +62,12 @@ let testTweets = [
     creator: "5aa054ac1a6e5a01b90f591d",
     user: "loopylenny",
     text: "A tweet by loopylenny"
+  },
+  {
+    _id: "5aa05812fcbbc803417de0b9",
+    creator: "5aa054ac1a6e5a01b90f591e",
+    user: "jackroads",
+    text: "It's jack roads, baby!"
   }
 ];
 

--- a/server/user.js
+++ b/server/user.js
@@ -35,6 +35,29 @@ router.get("/:user_id/tweets", (req, res) => {
     .catch(err => res.status(400).send(err));
 });
 
+// Get a user's feed
+router.get("/:self_id/feed", (req, res) => {
+  const self_id = req.params.self_id;
+
+  User.findById(self_id, function(err, self) {
+    // Get array of ObjectIDs (OIDs) from self and followed users
+    let feedOIDs = [self.get("following"), self_id];
+
+    // Turning our feedOID arr into an array of objects so that it will be accepted by $or
+    let query = feedOIDs.map(user_id => {
+      // Parse the array of OIDs into an array of objects
+      return { creator: user_id };
+    });
+
+    // Returns all tweets from every user referenced in feedOIDs, sorts by date
+    Tweet.find({ $or: query })
+      .sort({ date: "asc" })
+      .then(feed => {
+        res.send(feed);
+      });
+  });
+});
+
 // Get a user's information
 router.get("/:user_id/profile", (req, res) => {
   User.findById(req.params.user_id, function(err, user) {


### PR DESCRIPTION
## Changes
- Added a new test user, 'jackroads'
- Added a route for getting a user's feed
- Added a new test for feed route

## Routes
GET:  /users/${self_id}/feed

- Returns an array of tweet objects from the target user and all users the target user follows
- Feed is sorted by date ascending

## Tests
- Misoawesome is now following loopylenny and jackroads. This allows for testing that all followed users' tweets are included in the feed
- Test checks to see that 5 tweet objects are returned (3 from self, 1 from loopylenny, 1 from jackroads)