### PR TITLE
Be/refactor likes

### DIFF
--- a/server/__tests__/server.test.js
+++ b/server/__tests__/server.test.js
@@ -139,7 +139,7 @@ describe("LIKES", () => {
 
     request(app)
       .put(`/user/${user_id}/likes`)
-      .send({ tweet_id: tweet_id, action: "like" })
+      .send({ tweet_id: tweet_id })
       .expect(200)
       .expect(res => {
         expect(res.body.likes.length).toBe(2);
@@ -147,17 +147,16 @@ describe("LIKES", () => {
       .end(done);
   });
 
-  it.only("should remove a liked tweet from the likes array", done => {
+  it("should remove a liked tweet from the likes array", done => {
     const user_id = "5aa054ac1a6e5a01b90f591e";
     const tweet_id = "5aa05812fcbbc803417de0b8";
 
     request(app)
       .put(`/user/${user_id}/likes`)
-      .send({ tweet_id: tweet_id, action: "unlike" })
+      .send({ tweet_id: tweet_id })
       .expect(200)
       .expect(res => {
-        console.log(res.body);
-        expect(res.body.likesNum).toBe(1);
+        expect(res.body.likesNum).toBe(0);
       })
       .end(done);
   });

--- a/server/__tests__/server.test.js
+++ b/server/__tests__/server.test.js
@@ -133,7 +133,7 @@ describe("LIKES", () => {
       .end(done);
   });
 
-  it("should a liked post to a user model", done => {
+  it("should add liked tweet to likes array", done => {
     const user_id = "5aa054ac1a6e5a01b90f591d";
     const tweet_id = "5aa05812fcbbc803417de0b6";
 
@@ -147,8 +147,8 @@ describe("LIKES", () => {
       .end(done);
   });
 
-  it("should remove a liked tweet from the likes array", done => {
-    const user_id = "5aa054ac1a6e5a01b90f591d";
+  it.only("should remove a liked tweet from the likes array", done => {
+    const user_id = "5aa054ac1a6e5a01b90f591e";
     const tweet_id = "5aa05812fcbbc803417de0b8";
 
     request(app)
@@ -156,6 +156,7 @@ describe("LIKES", () => {
       .send({ tweet_id: tweet_id, action: "unlike" })
       .expect(200)
       .expect(res => {
+        console.log(res.body);
         expect(res.body.likesNum).toBe(1);
       })
       .end(done);

--- a/server/__tests__/test-data.js
+++ b/server/__tests__/test-data.js
@@ -28,7 +28,8 @@ let testUsers = [
     _id: "5aa054ac1a6e5a01b90f591e",
     username: "jackroads",
     firstName: "jack",
-    lastName: "roads"
+    lastName: "roads",
+    likes: ["5aa05812fcbbc803417de0b8"]
   }
 ];
 


### PR DESCRIPTION
## Changes
- PUT users/:user_id/likes route now only requires ***user_Id*** and ***tweet_id***
- Both like and unlike actions are handled according to whether a tweet is present in a user's likes array

## Tests
- Added a like tweet to jackroads
- Remove a tweet test is no longer dependent on add a tweet test completing first. This removes the possibility of a race condition