### PR TITLE
Fe/auth redirects

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -606,7 +606,7 @@ body {
 
 .search--form {
   margin: 0 auto;
-  padding: 0;
+  padding: 16px 0 0 0;
   width: 94%;
 }
 
@@ -635,7 +635,7 @@ body {
   font-size: 16px;
   width: 100%;
   margin: 16px 0px;
-  padding: 8px;
+  padding: 8px 0px;
   background: #00c8cd;
   border: 0px solid #e59eb4;
   border-radius: 5px;
@@ -742,6 +742,7 @@ body {
   line-height: 33px;
   text-align: center;
   margin: 0px 16px;
+  padding: 16px 0;
 }
 
 .login--container--signin-buttons {
@@ -863,5 +864,20 @@ body {
 }
 
 .scoop--characters-remaining {
+  color: #777;
+}
+
+.scoop--link {
+  font-weight: bold;
+  text-decoration: none;
+  color: #e59eb4;
+  transition: color 0.3s ease-in-out;
+}
+
+.scoop--link:hover {
+  color: #00c8cd;
+}
+
+.scoop--graytext {
   color: #777;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -665,7 +665,7 @@ body {
 .searchresults {
   margin: 0;
   background: #ffbacf;
-  padding: 0px 32px;
+  padding: 0;
 }
 
 .search--list {

--- a/src/components/EditProfile.js
+++ b/src/components/EditProfile.js
@@ -72,7 +72,7 @@ class EditProfile extends Component {
 
   render() {
     if (this.state.redirectToNewPage) {
-      return <Redirect to="/" />;
+      return <Redirect to="/login" />;
     }
 
     return (

--- a/src/components/FeedView.js
+++ b/src/components/FeedView.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import Feed from "./Feed";
 import axios from "axios";
+import { Redirect } from "react-router-dom";
 
 class FeedView extends Component {
   constructor(props) {
@@ -8,7 +9,8 @@ class FeedView extends Component {
     this.state = {
       profile: null,
       scoops: null,
-      selected: "everybody"
+      selected: "everybody",
+      redirectToNewPage: false
     };
     this.getAllScoops = this.getAllScoops.bind(this);
     this.getFollowingScoops = this.getFollowingScoops.bind(this);
@@ -30,11 +32,11 @@ class FeedView extends Component {
     axios
       .get("/user/feed")
       .then(response => {
-        console.log(response);
         this.setState({ scoops: response.data, selected: "following" });
       })
       .catch(error => {
         console.log(error);
+        this.setState({ redirectToNewPage: true });
       });
   }
 
@@ -43,6 +45,10 @@ class FeedView extends Component {
   }
 
   render() {
+    if (this.state.redirectToNewPage) {
+      return <Redirect to="/login" />;
+    }
+
     const everybodySelected = (
       <div className="feed--header">
         <div

--- a/src/components/Logout.js
+++ b/src/components/Logout.js
@@ -2,6 +2,13 @@ import React, { Component } from "react";
 import axios from "axios";
 
 class Logout extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+    this.combinedFunction = this.combinedFunction.bind(this);
+    this.handleLogout = this.handleLogout.bind(this);
+  }
+
   handleLogout() {
     axios
       .get("/auth/logout")
@@ -13,11 +20,16 @@ class Logout extends Component {
       });
   }
 
+  combinedFunction() {
+    this.handleLogout();
+    this.props.redir();
+  }
+
   render() {
     return (
       <div>
         <button
-          onClick={this.handleLogout}
+          onClick={this.combinedFunction}
           className="profile--button--edit-profile"
         >
           Logout

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -26,7 +26,7 @@ class Profile extends Component {
                     Edit Profile
                   </button>
                 </Link>
-                <Logout />
+                <Logout redir={this.props.redir} />
               </div>
             ) : (
               <button className="profile--button--edit-profile">Follow</button>

--- a/src/components/ProfileView.js
+++ b/src/components/ProfileView.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Link } from "react-router-dom";
+import { Link, Redirect } from "react-router-dom";
 import axios from "axios";
 import Profile from "./Profile";
 import Feed from "./Feed";
@@ -12,7 +12,8 @@ class ProfileView extends Component {
       scoops: null,
       userID: this.props.match.params.id,
       signedInUser: null,
-      signedInUserBoolean: false
+      signedInUserBoolean: false,
+      redirectToNewPage: false
     };
   }
 
@@ -50,12 +51,16 @@ class ProfileView extends Component {
       axios
         .get("auth/isAuthenticated")
         .then(response => {
-          this.setState({
-            signedInUser: response.data,
-            signedInUserBoolean: true
-          });
-          this.getUserProfile(response.data._id);
-          this.getAllScoops(response.data._id);
+          if (response.data != "Not logged in") {
+            this.setState({
+              signedInUser: response.data,
+              signedInUserBoolean: true
+            });
+            this.getUserProfile(response.data._id);
+            this.getAllScoops(response.data._id);
+          } else {
+            this.setState({ redirectToNewPage: true });
+          }
         })
         .catch(error => {
           console.log(error);
@@ -64,6 +69,10 @@ class ProfileView extends Component {
   }
 
   render() {
+    if (this.state.redirectToNewPage) {
+      return <Redirect to="/login" />;
+    }
+
     return (
       <div>
         {this.state.profile ? (
@@ -73,7 +82,7 @@ class ProfileView extends Component {
           />
         ) : null}
         {this.state.scoops ? <Feed scoops={this.state.scoops} /> : null}
-        {!this.state.scoops && !this.state.profile ? "Please log in" : null}
+        {!this.state.scoops && !this.state.profile ? "Loading" : null}
       </div>
     );
   }

--- a/src/components/ProfileView.js
+++ b/src/components/ProfileView.js
@@ -13,7 +13,10 @@ class ProfileView extends Component {
       userID: this.props.match.params.id,
       signedInUser: null,
       signedInUserBoolean: false,
-      redirectToNewPage: false
+      redirectToNewPage: false,
+      redir: () => {
+        this.setState({ redirectToNewPage: true });
+      }
     };
   }
 
@@ -79,6 +82,7 @@ class ProfileView extends Component {
           <Profile
             profile={this.state.profile}
             signedInUserBoolean={this.state.signedInUserBoolean}
+            redir={this.state.redir}
           />
         ) : null}
         {this.state.scoops ? <Feed scoops={this.state.scoops} /> : null}

--- a/src/components/Scoop.js
+++ b/src/components/Scoop.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Redirect } from "react-router-dom";
+import { Redirect, Link } from "react-router-dom";
 import axios from "axios";
 
 class Scoop extends Component {
@@ -8,7 +8,10 @@ class Scoop extends Component {
     this.state = {
       scoopText: "",
       remainingCharacters: 200,
-      redirectToNewPage: false
+      redirectToNewPage: false,
+      username: "",
+      firstname: "",
+      signedIn: false
     };
     this.handleChange = this.handleChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -38,7 +41,40 @@ class Scoop extends Component {
       });
   }
 
+  componentDidMount() {
+    axios
+      .get("auth/isAuthenticated")
+      .then(response => {
+        if (response.data.username) {
+          this.setState({
+            username: response.data.username || "",
+            firstname: response.data.firstName || "",
+            signedIn: true
+          });
+        } else {
+          this.setState({ signedIn: false });
+        }
+      })
+      .catch(error => {
+        console.log(error);
+      });
+  }
+
   render() {
+    const loggedOutElement = (
+      <span className="scoop--graytext">
+        Please{" "}
+        <Link to="/login" className="scoop--link">
+          sign in
+        </Link>
+      </span>
+    );
+    const loggedInElement = (
+      <span className="scoop--graytext">
+        Give us the details, {this.state.username}!
+      </span>
+    );
+
     if (this.state.redirectToNewPage) {
       return <Redirect to="/" />;
     }
@@ -47,6 +83,7 @@ class Scoop extends Component {
       <div className="scoop--container">
         <div className="scoop">
           <h1 className="scoop--header">What's the scoop?</h1>
+          {this.state.signedIn ? loggedInElement : loggedOutElement}
           <form onSubmit={this.handleSubmit} className="scoop--form">
             <textarea
               value={this.state.scoopText}

--- a/src/styles/components/_login.scss
+++ b/src/styles/components/_login.scss
@@ -32,6 +32,7 @@
   line-height: $line-height * 1.5;
   text-align: center;
   margin: 0px 16px;
+  padding: 16px 0;
 }
 
 .login--container--signin-buttons {

--- a/src/styles/components/_scoop.scss
+++ b/src/styles/components/_scoop.scss
@@ -77,3 +77,18 @@
 .scoop--characters-remaining {
   color: $brand-color-gray;
 }
+
+.scoop--link {
+  font-weight: bold;
+  text-decoration: none;
+  color: $brand-color-pink;
+  transition: color 0.3s ease-in-out;
+}
+
+.scoop--link:hover {
+  color: $brand-color-green;
+}
+
+.scoop--graytext {
+  color: $brand-color-gray;
+}

--- a/src/styles/components/_search.scss
+++ b/src/styles/components/_search.scss
@@ -28,7 +28,7 @@
 
 .search--form {
   margin: 0 auto;
-  padding: 0;
+  padding: 16px 0 0 0;
   width: 94%;
 }
 
@@ -57,7 +57,7 @@
   font-size: $font-size;
   width: 100%;
   margin: 16px 0px;
-  padding: 8px;
+  padding: 8px 0px;
   background: $brand-color-green;
   border: 0px solid $brand-color-pink;
   border-radius: 5px;

--- a/src/styles/components/_search.scss
+++ b/src/styles/components/_search.scss
@@ -91,7 +91,7 @@
 .searchresults {
   margin: 0;
   background: $brand-color-lightpink;
-  padding: 0px 32px;
+  padding: 0;
 }
 
 .search--list {


### PR DESCRIPTION
Added re-routes to / and /login when attempting to click on or view parts of components requiring authorization.

- /profile (not /profile:id)
- /editprofile
- /profile, after clicking logout
- /feed, when clicking 'following' link
- /scoop, notification to log in if logged out